### PR TITLE
Updating sklearn.cross_validation to sklearn.model_selection

### DIFF
--- a/costcla/models/cost_ensemble.py
+++ b/costcla/models/cost_ensemble.py
@@ -5,7 +5,7 @@ This module include the cost sensitive ensemble methods.
 # Authors: Alejandro Correa Bahnsen <al.bahnsen@gmail.com>
 # License: BSD 3 clause
 
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 from ..models import CostSensitiveDecisionTreeClassifier
 from ..models.bagging import BaggingClassifier
 


### PR DESCRIPTION
This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved.