### PR TITLE
Updated link to tutorials

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,8 @@ Documentation is available at
 http://albahnsen.github.com/CostSensitiveClassification
 
 Tutorials are available at
-http://albahnsen.com/CostSensitiveClassification/Tutorials.html
+http://albahnsen.github.io/CostSensitiveClassification/Tutorials.html
+
 
 Development
 =============


### PR DESCRIPTION
Updated link to tutorials to http://albahnsen.github.io/CostSensitiveClassification/Tutorials.html 